### PR TITLE
fix: getJsonValue don't have parent

### DIFF
--- a/util/util.js
+++ b/util/util.js
@@ -24,7 +24,7 @@ function getJsonValue(model = {}, path = "", def = "") {
     const parts = path.split(".");
 
     if (parts.length > 1 && typeof model[parts[0]] === "object") {
-        return this.getJsonValue(
+        return getJsonValue(
             model[parts[0]],
             parts.splice(1).join("."),
             def,

--- a/util/util.js
+++ b/util/util.js
@@ -24,11 +24,7 @@ function getJsonValue(model = {}, path = "", def = "") {
     const parts = path.split(".");
 
     if (parts.length > 1 && typeof model[parts[0]] === "object") {
-        return getJsonValue(
-            model[parts[0]],
-            parts.splice(1).join("."),
-            def,
-        );
+        return getJsonValue(model[parts[0]], parts.splice(1).join("."), def);
     }
 
     return model[parts[0]] || def;


### PR DESCRIPTION
getJsonValue is no longer a member of an object as in modules.exports since the refactor