### PR TITLE
Ajout info boss + fix classement

### DIFF
--- a/slash_commands/subcommands/tower/index.js
+++ b/slash_commands/subcommands/tower/index.js
@@ -1,9 +1,11 @@
 const { inscription } = require("./inscription");
 const { validerJeu } = require("./valider-jeu");
 const { classement } = require("./classement");
+const { infoBoss } = require("./info-boss");
 
 module.exports = {
     inscription,
     validerJeu,
     classement,
+    infoBoss,
 };

--- a/slash_commands/subcommands/tower/info-boss.js
+++ b/slash_commands/subcommands/tower/info-boss.js
@@ -1,0 +1,47 @@
+const { displayHealth, getRandomPrivateJokes } = require("./valider-jeu");
+const { TowerBoss, GuildConfig } = require("../../../models");
+const { EmbedBuilder } = require("discord.js");
+
+const infoBoss = async (interaction, options) => {
+    const guildId = interaction.guildId;
+    const guild = await GuildConfig.findOne({ guildId: guildId });
+    const season = guild.event.tower.currentSeason;
+    if (typeof season === "undefined") {
+        return interaction.reply({
+            content: "Aucune saison en cours.",
+            ephemeral: true,
+        });
+    }
+
+    // Récupère le boss courant non mort
+    const currentBoss = await TowerBoss.findOne({
+        season: season,
+        hp: { $ne: 0 },
+    });
+    if (!currentBoss) {
+        return interaction.reply({
+            content: "Aucun boss n'est actif actuellement.",
+            ephemeral: true,
+        });
+    }
+
+    const description = `**Nom :** ${currentBoss.name}`;
+
+    const embed = new EmbedBuilder()
+        .setTitle("Information sur le boss courant")
+        .setDescription(description)
+        .setColor("#fffb00")
+        .setFooter({
+            text: `${getRandomPrivateJokes()}`,
+        });
+    embed.addFields({
+        name: `${currentBoss.hp}/${currentBoss.maxHp}`,
+        value: `${displayHealth(currentBoss)}`,
+    });
+
+    return interaction.reply({
+        embeds: [embed],
+    });
+};
+
+exports.infoBoss = infoBoss;

--- a/slash_commands/subcommands/tower/valider-jeu.js
+++ b/slash_commands/subcommands/tower/valider-jeu.js
@@ -39,9 +39,11 @@ function displayHealth(boss) {
 
     // Sélection des émojis de couleur selon le ratio de vie
     let filledEmoji = "🟩"; // Par défaut, plein de vie
-    if (boss.hp / boss.maxHp <= 0.3)
+    if (boss.hp / boss.maxHp <= 0.3) {
         filledEmoji = "🟥"; // Faible santé
-    else if (boss.hp / boss.maxHp <= 0.6) filledEmoji = "🟨"; // Santé moyenne
+    } else if (boss.hp / boss.maxHp <= 0.6) {
+        filledEmoji = "🟨"; // Santé moyenne
+    }
     const intermediateEmoji = "🟧"; // Émoji intermédiaire
     const emptyEmoji = "⬜"; // Cases vides plus douces
 
@@ -589,3 +591,5 @@ async function endSeasonForUser(user, endDate, seasonNumber) {
 
 exports.validerJeu = validerJeu;
 exports.endSeasonForUser = endSeasonForUser;
+exports.displayHealth = displayHealth;
+exports.getRandomPrivateJokes = getRandomPrivateJokes;

--- a/slash_commands/tower.js
+++ b/slash_commands/tower.js
@@ -1,5 +1,10 @@
 const { SlashCommandBuilder } = require("discord.js");
-const { inscription, validerJeu, classement } = require("./subcommands/tower");
+const {
+    inscription,
+    validerJeu,
+    classement,
+    infoBoss,
+} = require("./subcommands/tower");
 const { Game } = require("../models");
 const { escapeRegExp } = require("../util/util");
 
@@ -17,6 +22,11 @@ module.exports = {
             sub
                 .setName("classement")
                 .setDescription("Classement de l'événement"),
+        )
+        .addSubcommand((sub) =>
+            sub
+                .setName("info-boss")
+                .setDescription("Informations liées au boss"),
         )
         .addSubcommand((sub) =>
             sub
@@ -103,6 +113,8 @@ module.exports = {
             await validerJeu(interaction, interaction.options);
         } else if (subcommand === "classement") {
             await classement(interaction, interaction.options);
+        } else if (subcommand === "info-boss") {
+            await infoBoss(interaction, interaction.options);
         }
     },
 };


### PR DESCRIPTION
ajout d'une commande `/tower info-boss` qui affiche simplement l'état du boss courant
![image](https://github.com/user-attachments/assets/6e9e3b17-caca-48e1-a07e-cfbbf9ef35ea)

fix du classement qui n'affichait pas la position de l'utilisateur courant si celui-ci n'était pas dans le top 10