### PR TITLE
fix: typos and 1 undefined

### DIFF
--- a/slash_commands/subcommands/admin/shop/cancel.js
+++ b/slash_commands/subcommands/admin/shop/cancel.js
@@ -22,7 +22,7 @@ async function cancel(interaction, options) {
         return interaction.reply({
             embeds: [
                 createError(
-                    "La vente n'a pas encore **commencée** ! Utiliser `/adminshop delete <id>`",
+                    "La vente n'a pas encore **commencée** ! Utiliser `/admin shop delete <id>`",
                 ),
             ],
         });
@@ -32,7 +32,7 @@ async function cancel(interaction, options) {
         return interaction.reply({
             embeds: [
                 createError(
-                    "La vente est déjà **terminée** ! Utiliser `/adminshop refund <id>`",
+                    "La vente est déjà **terminée** ! Utiliser `/admin shop refund <id>`",
                 ),
             ],
         });

--- a/slash_commands/subcommands/admin/shop/delete.js
+++ b/slash_commands/subcommands/admin/shop/delete.js
@@ -21,7 +21,7 @@ async function deleteItem(interaction, options) {
         return interaction.reply({
             embeds: [
                 createError(
-                    "L'item ne doit pas être encore en cours de vente ! Utiliser `/adminshop cancel <id>` ou `/shop admin refund <id>`",
+                    "L'item ne doit pas être encore en cours de vente ! Utiliser `/admin shop cancel <id>` ou `/shop admin refund <id>`",
                 ),
             ],
         });

--- a/slash_commands/subcommands/admin/shop/refund.js
+++ b/slash_commands/subcommands/admin/shop/refund.js
@@ -24,7 +24,7 @@ async function refund(interaction, options) {
         return interaction.reply({
             embeds: [
                 createError(
-                    "La vente n'a pas encore **commencée** ! Utiliser `/adminshop delete <id>`",
+                    "La vente n'a pas encore **commencée** ! Utiliser `/admin shop delete <id>`",
                 ),
             ],
         });
@@ -34,7 +34,7 @@ async function refund(interaction, options) {
         return interaction.reply({
             embeds: [
                 createError(
-                    "La vente n'est pas encore **terminée** ! Utiliser `/adminshop cancel <id>`",
+                    "La vente n'est pas encore **terminée** ! Utiliser `/admin shop cancel <id>`",
                 ),
             ],
         });

--- a/slash_commands/subcommands/group/dissolve.js
+++ b/slash_commands/subcommands/group/dissolve.js
@@ -1,7 +1,7 @@
 const { PermissionFlagsBits } = require("discord.js");
 const { createError, createLogs } = require("../../../util/envoiMsg");
 const { dissolveGroup } = require("../../../util/msg/group");
-const { WARNING } = require("../../../data/colors.json");
+const { WARNING } = require("../../../data/emojis.json");
 
 const dissolve = async (interaction, options) => {
     const grpName = options.get("nom")?.value;

--- a/slash_commands/subcommands/group/session.js
+++ b/slash_commands/subcommands/group/session.js
@@ -119,7 +119,7 @@ const schedule = async (interaction, options) => {
                 const dateStr = `${dateVoulue} à ${heureVoulue}`;
                 if (indexDateEvent >= 0) {
                     channel.send(
-                        `> ! La session du **${dateStr}** a été **supprimée**.`,
+                        `> ⚠️ La session du **${dateStr}** a été **supprimée**.`,
                     );
                 } else {
                     channel.send(`> 🗓 Nouvelle session le **${dateStr}** !`);


### PR DESCRIPTION
Fix de quelques erreurs de typos : 
- De message d'erreur d'utilisation sur des commandes admin shop (ancienne commande) 
- Changement du ! en ⚠️ pour le message de suppression de session de groupe

Fix d'un mauvais import qui renvois `undefined` lors de la dissolution d'un groupe